### PR TITLE
Add Search Funcitonality From District Repository

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -11,27 +11,25 @@ class App extends Component {
     this.state = {
       schoolData: {},
       searchResults: [],
+      districtRepository: {},
     }
     this.handleSearch = this.handleSearch.bind(this);
   }
 
   componentDidMount() {
-    let district = this.getCleanData(kinderData);
-    this.setState({
-      schoolData: district,
-    })
+    this.getDistrictRepository(kinderData);
   }
 
-  getCleanData(schoolData) {
-    return new DistrictRepository(schoolData).data
+  getDistrictRepository(schoolData) {
+    let districtRepository = new DistrictRepository(schoolData);
+    this.setState({ districtRepository, schoolData: districtRepository.data })
   }
 
   handleSearch(e) {
-    let schoolsToSearch = Object.keys(this.state.schoolData);
-    let searchResults = schoolsToSearch.filter( schoolName => schoolName
-      .includes(e.target.value.toUpperCase()))
-      .map( schoolName => this.state.schoolData[schoolName]);
-    this.setState({searchResults})
+    this.setState({ 
+      searchResults: this.state.districtRepository
+                      .findAllMatches(e.target.value)
+    })
   }
 
   render() {

--- a/src/components/App/App.test.js
+++ b/src/components/App/App.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import App from './App';
 import kinderData from '../../data/kindergartners_in_full_day_program.js';
@@ -11,10 +11,28 @@ it('should have a default state equal to the cleaned data', () => {
   expect(wrapper.state().schoolData[Object.keys(wrapper.state().schoolData)[0]]).toEqual(cleanedData);
 });
 
-it('should grab clean data', () => {
+it('should update state with a new instance of DistrictRepository', () => {
   const wrapper = shallow(<App />);
   const rawData = [{Location: 'Colorado', TimeFrame: 2007, DataFormat:'Percent', Data:.337}]
-  const cleanData = {"COLORADO": {"data": {"2007": 0.337}, "dataType": "Percent", "location": "COLORADO"}}
-  let newData = wrapper.instance().getCleanData(rawData);
-  expect(newData).toEqual(cleanData);
+  const cleanData = {"data": {"COLORADO": {"data": {"2007": 0.337}, "dataType": "Percent", "location": "COLORADO"}}}
+  wrapper.instance().getDistrictRepository(rawData);
+  expect(wrapper.state().districtRepository).toEqual(cleanData);
+});
+
+it('should update state when handleSearch is activated', () => {
+  const wrapper = mount(<App />);
+  let searchDataReplica = {"data": {"2004": 0.302, "2005": 0.267, "2006": 0.354, "2007": 0.392, "2008": 0.385, "2009": 0.39, "2010": 0.436, "2011": 0.489, "2012": 0.479, "2013": 0.488, "2014": 0.49}, "dataType": "Percent", "location": "ACADEMY 20"};
+  
+  expect(wrapper.find('input').simulate('change', {target: {value: 'col'}}));
+  expect(wrapper.state().searchResults.length).toEqual(2);
+  
+  expect(wrapper.find('input').simulate('change', {target: {value: 'aca'}}));
+  expect(wrapper.state().searchResults.length).toEqual(1);
+  expect(wrapper.state().searchResults).toEqual([searchDataReplica]);
+
+
+
+
+
+  
 });

--- a/src/helper.js
+++ b/src/helper.js
@@ -28,14 +28,13 @@ class DistrictRepository {
   }
     
   findAllMatches(searchFrag = '') {
-    let dataKeys = Object.keys(this.data).map( dataPoint => dataPoint);
-    let array = [];
-    dataKeys.forEach(key => {
-      if (key.includes(searchFrag.toUpperCase())) {
-        array.push(this.data[key]);
-      }
+    let searchResults = [];
+    Object.keys(this.data).map( dataPoint => dataPoint)
+      .forEach(key => {
+        key.includes(searchFrag.toUpperCase()) 
+        && searchResults.push(this.data[key]);
     } );
-    return array;
+    return searchResults;
   }
 }
 


### PR DESCRIPTION
Change state to hold an instance of DirectRespository. When getDirectRepository is called, sets state to hold the instance and updates school data. Also, on search, uses the DirectRespository findAllMatches method to return the array. Closes 18