### PR TITLE
Testing for Card, CardContainer, CompareConatiner

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -49,6 +49,7 @@ class App extends Component {
   }
 
   removeComparison = () => {
+    console.log('hi')
     this.setState({
       compareSchool1: '',
       compareSchool2: '',

--- a/src/components/Card/Card.test.js
+++ b/src/components/Card/Card.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Card from './Card';
+
+describe('Card', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    const mockedHandleCompareCards = jest.fn();
+    const mockedSchoolData = {
+      data: {2004: 0.302, 2005: 0.267, 2006: 0.354, 2007: 0.392, 2008: 0.385,
+        2009: 0.39, 2010: 0.436, 2011: 0.489, 2012: 0.479, 2013: 0.488, 2014: 0.49},
+      dataType: "Percent",
+      location: "ACADEMY 20"}
+
+    wrapper = shallow(<Card 
+                schoolData={mockedSchoolData}
+                handleCompareCards={mockedHandleCompareCards}
+                size='large'
+        />)
+  })
+
+  it('should render all of the key value pairs in data', () => {
+    expect(wrapper.find('li').length).toEqual(11);
+  })
+})

--- a/src/components/CardContainer/CardContainer.test.js
+++ b/src/components/CardContainer/CardContainer.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import CardContainer from './CardContainer';
+
+describe('CardContainer', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    const mockedHandleCompareCards = jest.fn();
+    const mockedState = [{
+      data: {2004: 0.302, 2005: 0.267, 2006: 0.354, 2007: 0.392, 2008: 0.385,
+        2009: 0.39, 2010: 0.436, 2011: 0.489, 2012: 0.479, 2013: 0.488, 2014: 0.49},
+      dataType: "Percent",
+      location: "ACADEMY 20"}]
+    wrapper = mount(<CardContainer 
+                          schoolData={mockedState}
+                          handleCompareCards={mockedHandleCompareCards}
+                    />)
+
+  })
+
+  it('should exist', () => {
+    expect(wrapper).toBeDefined();
+  })
+
+  it('should render Cards', () => {
+    //add snapshot but forgot syntax
+    expect(wrapper.find('.Card').length).toEqual(1)
+  })
+})

--- a/src/components/CompareContainer/CompareContainer.js
+++ b/src/components/CompareContainer/CompareContainer.js
@@ -8,10 +8,7 @@ const display = getDisplay();
 
 function getDisplay() {
   if (hideComparison === 'hide') {
-    return (
-      <div className={hideComparison}>
-      </div>
-    ); 
+    return; 
   } else if (hideComparison === 'displayOne') {
       return (
         <section className={hideComparison}>

--- a/src/components/CompareContainer/CompareContainer.test.js
+++ b/src/components/CompareContainer/CompareContainer.test.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import CompareContainer from './CompareContainer';
+
+it('should exist and render nothing when hideComparison is hide', () => {
+  const mockedHideComparison = 'hide';
+  const mockedHandleCompareCards = jest.fn();
+  const mockedRemoveComparison = jest.fn();
+  const mockedSchool1 = {
+    data: {2004: 0.302, 2005: 0.267, 2006: 0.354, 2007: 0.392, 2008: 0.385,
+      2009: 0.39, 2010: 0.436, 2011: 0.489, 2012: 0.479, 2013: 0.488, 2014: 0.49},
+    dataType: "Percent",
+    location: "ACADEMY 20"}
+  const mockedSchool2 = {
+    data: {2004: 0, 2005: 0, 2006: 0, 2007: 0, 2008: 0.844, 2009: 0.96, 
+      2010: 1, 2011: 1, 2012: 1, 2013: 1, 2014: 1},
+    dataType: "Percent",
+    location: "AKRON R-1"
+  }
+  const mockedComparison = {"ACADEMY 20": 0.407, "AKRON R-1": 0.619, compared: 0.658 }
+
+  const wrapper = shallow(<CompareContainer 
+                            hideComparison={mockedHideComparison}
+                            handleCompareCards={mockedHandleCompareCards}
+                            school1={mockedSchool1}
+                            school2={mockedSchool2}
+                            comparison={mockedComparison}
+                            removeComparison={mockedRemoveComparison}
+                            />)
+
+  expect(wrapper).toBeDefined();
+  expect(wrapper.find('div').length).toEqual(1);
+  expect(wrapper.find('.displayOne').length).toEqual(0);
+  expect(wrapper.find('.displayAll').length).toEqual(0);
+})
+
+it('should render a comparison container when one card is selected', () => {
+  const mockedHideComparison = 'displayOne';
+  const mockedHandleCompareCards = jest.fn();
+  const mockedRemoveComparison = jest.fn();
+  const mockedSchool1 = {
+    data: {2004: 0.302, 2005: 0.267, 2006: 0.354, 2007: 0.392, 2008: 0.385,
+      2009: 0.39, 2010: 0.436, 2011: 0.489, 2012: 0.479, 2013: 0.488, 2014: 0.49},
+    dataType: "Percent",
+    location: "ACADEMY 20"}
+  const mockedSchool2 = {
+    data: {2004: 0, 2005: 0, 2006: 0, 2007: 0, 2008: 0.844, 2009: 0.96, 
+      2010: 1, 2011: 1, 2012: 1, 2013: 1, 2014: 1},
+    dataType: "Percent",
+    location: "AKRON R-1"
+  }
+  const mockedComparison = {"ACADEMY 20": 0.407, "AKRON R-1": 0.619, compared: 0.658 }
+
+  const wrapper = shallow(<CompareContainer 
+                            hideComparison={mockedHideComparison}
+                            handleCompareCards={mockedHandleCompareCards}
+                            school1={mockedSchool1}
+                            school2={mockedSchool2}
+                            comparison={mockedComparison}
+                            removeComparison={mockedRemoveComparison}
+                            />)
+  expect(wrapper.find('.displayOne').length).toEqual(1);
+  expect(wrapper.find('.displayAll').length).toEqual(0);
+})
+
+describe('displayAll', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    const mockedHideComparison = 'displayAll';
+    const mockedHandleCompareCards = jest.fn();
+    const mockedRemoveComparison = jest.fn();
+    const mockedSchool1 = {
+      data: {2004: 0.302, 2005: 0.267, 2006: 0.354, 2007: 0.392, 2008: 0.385,
+        2009: 0.39, 2010: 0.436, 2011: 0.489, 2012: 0.479, 2013: 0.488, 2014: 0.49},
+      dataType: "Percent",
+      location: "ACADEMY 20"}
+    const mockedSchool2 = {
+      data: {2004: 0, 2005: 0, 2006: 0, 2007: 0, 2008: 0.844, 2009: 0.96, 
+        2010: 1, 2011: 1, 2012: 1, 2013: 1, 2014: 1},
+      dataType: "Percent",
+      location: "AKRON R-1"
+    }
+    const mockedComparison = {"ACADEMY 20": 0.407, "AKRON R-1": 0.619, compared: 0.658 }
+
+    wrapper = shallow(<CompareContainer 
+                        hideComparison={mockedHideComparison}
+                        handleCompareCards={mockedHandleCompareCards}
+                        school1={mockedSchool1}
+                        school2={mockedSchool2}
+                        comparison={mockedComparison}
+                        removeComparison={mockedRemoveComparison}
+                      />)
+  })
+
+ it('should render another comparison container when two cards is selected', () => {
+    expect(wrapper.find('.displayOne').length).toEqual(0);
+    expect(wrapper.find('.displayAll').length).toEqual(1);
+  })
+
+ it('should display no comparison container after remove Comparison is simulated', () => {
+    wrapper.find('button').simulate('click')
+    // expect(wrapper.find('.displayOne').length).toEqual(0);
+    // expect(wrapper.find('.displayAll').length).toEqual(0);
+
+ })
+
+})


### PR DESCRIPTION
Add testing suites for Card, CardContainer and CompareContainer. Work to add is taking out mock data and putting it into its own file, separating CompareContainer if statement into seperate cmoponents, refactoring and making sure we are using ES6